### PR TITLE
Use official Kotlin style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,24 @@ The code style definition follows [Google's general guidelines](https://google.g
 There are, however, a few rules which we ourselves override and some that are not mentioned above:
 
 - The line length is 120 characters long;
-- No copywrite notice is included at the top of files;
+- No copyright notice is included at the top of files;
 - Import order and paragraphs are not managed manually by the developer, but instead automatically by IntelliJ / Android Studio;
 - The single parameterless annotation exception is never used, as annotations are always placed in their own line, except annotations on method parameters which can go on the same line;
 - Exceptions widely known to be safe to ignore can be ignored (common in Android and some libraries). It's better not to show a tooltip at a given moment than to crash the app for the user;
 - Non-public static member variables are prefixed with `s`, all others follow the conventions mentioned in the documents;
 - All comments always start capitalized and end with a period. They're written English, so they follow the written English rules;
 - Getters and setters are intercalated. `setEmail` follows `getEmail`.
-- Parcelable code goes at the end of the class in the following order: constructor, `writeToParcel`, `CREATOR` and `describeContents`. Follows the usual reader / writer flow and orders methods by usefulness and likelyhood of change. There's a [useful IntelliJ plug-in](https://github.com/goncalossilva/android-parcelable-intellij-plugin/raw/master/android-parcelable-intellij-plugin.jar) for this.
+- Parcelable code goes at the end of the class in the following order: constructor, `writeToParcel`, `CREATOR` and `describeContents`. Follows the usual reader / writer flow and orders methods by usefulness and likelihood of change. There's a [useful IntelliJ plug-in](https://github.com/goncalossilva/android-parcelable-intellij-plugin/raw/master/android-parcelable-intellij-plugin.jar) for this.
 
 ## Kotlin
 
-The code style definition follows [the official style guide](https://android.github.io/kotlin-guides/style.html), with a few changes and additional rules not mentioned above:
+The code style definition follows the official [Kotlin style guide](https://kotlinlang.org/docs/reference/coding-conventions.html), with a few changes and additional rules not mentioned above:
 - The line length is 120 characters long;
-- No copywrite notice is included at the top of files;
+- No copyright notice is included at the top of files;
 - Import order and paragraphs are not managed manually by the developer, but instead automatically by IntelliJ / Android Studio;
 - Exceptions widely known to be safe to ignore can be ignored (common in Android and some libraries). It's better not to show a tooltip at a given moment than to crash the app for the user;
 - All comments always start capitalized and end with a period. They're written English, so they follow the written English rules;
-- Parcelable code goes at the end of the class in the following order: constructor, `writeToParcel`, `CREATOR` and `describeContents`. Follows the usual reader / writer flow and orders methods by usefulness and likelyhood of change. Better yet, use [`@Parcelize`](https://github.com/Kotlin/KEEP/blob/master/proposals/extensions/android-parcelable.md).
+- Parcelable code goes at the end of the class in the following order: constructor, `writeToParcel`, `CREATOR` and `describeContents`. Follows the usual reader / writer flow and orders methods by usefulness and likelihood of change. Better yet, use [`@Parcelize`](https://github.com/Kotlin/KEEP/blob/master/proposals/extensions/android-parcelable.md).
  
 ## Save actions in Android Studio
 

--- a/configs/DoistAndroid.xml
+++ b/configs/DoistAndroid.xml
@@ -1,95 +1,43 @@
-<code_scheme name="DoistStyle">
-  <option name="JAVA_INDENT_OPTIONS">
-    <value>
-      <option name="INDENT_SIZE" value="4" />
-      <option name="CONTINUATION_INDENT_SIZE" value="8" />
-      <option name="TAB_SIZE" value="8" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
-    </value>
-  </option>
-  <option name="FIELD_NAME_PREFIX" value="m" />
-  <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
-  <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-    <value />
-  </option>
-  <option name="IMPORT_LAYOUT_TABLE">
-    <value>
-      <package name="com.google" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="com" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="junit" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="net" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="org" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="android" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="java" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javax" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
-    </value>
-  </option>
-  <option name="JD_P_AT_EMPTY_LINES" value="false" />
-  <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
-  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-  <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
-  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-  <option name="BLANK_LINES_AROUND_FIELD" value="1" />
-  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-  <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-  <option name="ALIGN_MULTILINE_FOR" value="false" />
-  <option name="CALL_PARAMETERS_WRAP" value="1" />
-  <option name="METHOD_PARAMETERS_WRAP" value="1" />
-  <option name="EXTENDS_LIST_WRAP" value="1" />
-  <option name="THROWS_LIST_WRAP" value="1" />
-  <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="1" />
-  <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-  <option name="BINARY_OPERATION_WRAP" value="1" />
-  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-  <option name="TERNARY_OPERATION_WRAP" value="1" />
-  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-  <option name="FOR_STATEMENT_WRAP" value="1" />
-  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-  <option name="ASSIGNMENT_WRAP" value="1" />
-  <option name="WRAP_COMMENTS" value="true" />
-  <option name="IF_BRACE_FORCE" value="3" />
-  <option name="DOWHILE_BRACE_FORCE" value="3" />
-  <option name="WHILE_BRACE_FORCE" value="3" />
-  <option name="FOR_BRACE_FORCE" value="3" />
-  <AndroidXmlCodeStyleSettings>
-    <option name="USE_CUSTOM_SETTINGS" value="true" />
-  </AndroidXmlCodeStyleSettings>
+<code_scheme name="DoistStyle" version="173">
+  <option name="RIGHT_MARGIN" value="100" />
   <JavaCodeStyleSettings>
+    <option name="FIELD_NAME_PREFIX" value="m" />
+    <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
     <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="com.google" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="com" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="junit" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="net" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="org" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="android" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="java" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="true" />
+      </value>
+    </option>
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">
       <value />
     </option>
-    <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="999" />
-    <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="999" />
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
   </JetCodeStyleSettings>
   <XML>
-    <option name="XML_KEEP_LINE_BREAKS" value="false" />
     <option name="XML_KEEP_BLANK_LINES" value="1" />
-    <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-    <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
   </XML>
   <ADDITIONAL_INDENT_OPTIONS fileType="js">
@@ -122,7 +70,6 @@
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
@@ -149,11 +96,11 @@
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
     <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="WRAP_COMMENTS" value="true" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     <indentOptions>
       <option name="TAB_SIZE" value="8" />
     </indentOptions>
@@ -188,7 +135,6 @@
     <option name="PARENT_SETTINGS_INSTALLED" value="true" />
   </codeStyleSettings>
   <codeStyleSettings language="XML">
-    <option name="FORCE_REARRANGE_MODE" value="1" />
     <indentOptions>
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
     </indentOptions>
@@ -200,6 +146,7 @@
               <AND>
                 <NAME>xmlns:android</NAME>
                 <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
           </rule>
@@ -210,6 +157,7 @@
               <AND>
                 <NAME>xmlns:.*</NAME>
                 <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
             <order>BY_NAME</order>
@@ -220,6 +168,7 @@
             <match>
               <AND>
                 <NAME>.*:id</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -230,6 +179,7 @@
             <match>
               <AND>
                 <NAME>.*:name</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -240,6 +190,7 @@
             <match>
               <AND>
                 <NAME>name</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -250,6 +201,7 @@
             <match>
               <AND>
                 <NAME>style</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -260,6 +212,7 @@
             <match>
               <AND>
                 <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -270,7 +223,8 @@
           <rule>
             <match>
               <AND>
-                <NAME>.*:layout_width</NAME>
+                <NAME>layout_width</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -280,7 +234,8 @@
           <rule>
             <match>
               <AND>
-                <NAME>.*:layout_height</NAME>
+                <NAME>layout_height</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -290,33 +245,11 @@
           <rule>
             <match>
               <AND>
-                <NAME>.*:layout_.*</NAME>
+                <NAME>layout_.*</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
-            <order>BY_NAME</order>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <NAME>.*:width</NAME>
-                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-              </AND>
-            </match>
-            <order>BY_NAME</order>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <NAME>.*:height</NAME>
-                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-              </AND>
-            </match>
-            <order>BY_NAME</order>
           </rule>
         </section>
         <section>
@@ -324,6 +257,7 @@
             <match>
               <AND>
                 <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -334,7 +268,8 @@
           <rule>
             <match>
               <AND>
-                <NAME>.*:layout_.*</NAME>
+                <NAME>layout_.*</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
               </AND>
             </match>
@@ -346,6 +281,7 @@
             <match>
               <AND>
                 <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
               </AND>
             </match>
@@ -357,6 +293,7 @@
             <match>
               <AND>
                 <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
                 <XML_NAMESPACE>.*</XML_NAMESPACE>
               </AND>
             </match>
@@ -367,9 +304,12 @@
     </arrangement>
   </codeStyleSettings>
   <codeStyleSettings language="kotlin">
-    <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-    <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+    </indentOptions>
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
The base for Kotlin is now the official style with small deviations.

Main changes:
- Continuation indentation is 4.
- Maximum blank lines is 1.