### PR TITLE
Use default Android XML attribute order

### DIFF
--- a/configs/DoistStyle.xml
+++ b/configs/DoistStyle.xml
@@ -225,69 +225,12 @@
           <rule>
             <match>
               <AND>
-                <NAME>layout_width</NAME>
-                <XML_ATTRIBUTE />
-                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <NAME>layout_height</NAME>
-                <XML_ATTRIBUTE />
-                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <NAME>layout_.*</NAME>
-                <XML_ATTRIBUTE />
-                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
                 <NAME>.*</NAME>
                 <XML_ATTRIBUTE />
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
-            <order>BY_NAME</order>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <NAME>layout_.*</NAME>
-                <XML_ATTRIBUTE />
-                <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
-              </AND>
-            </match>
-            <order>BY_NAME</order>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <NAME>.*</NAME>
-                <XML_ATTRIBUTE />
-                <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
-              </AND>
-            </match>
-            <order>BY_NAME</order>
+            <order>ANDROID_ATTRIBUTE_ORDER</order>
           </rule>
         </section>
         <section>


### PR DESCRIPTION
Fixes issue with using alphabetical order even for `android` namespace.