### PR TITLE
Disable empty line between multiline when entries

### DIFF
--- a/configs/codestyles/DoistStyle.xml
+++ b/configs/codestyles/DoistStyle.xml
@@ -31,16 +31,11 @@
     </option>
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
-    <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-      <value />
-    </option>
-    <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-    <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+    <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
     <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
   </JetCodeStyleSettings>
   <XML>
     <option name="XML_KEEP_BLANK_LINES" value="1" />
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
   </XML>
   <ADDITIONAL_INDENT_OPTIONS fileType="js">
     <option name="CONTINUATION_INDENT_SIZE" value="4" />


### PR DESCRIPTION
Fixes a bug in IntelliJ, which doesn't respect "Blank Lines > Minimum blank lines around > Around 'when' branches with {}" when set to `0`. There's a new conflicting toggle "Wrapping and Braces > 'when' statements > Newline after multiline entry" which defaults to `true`.

This PR disables the latter; the other changes are due to the changes in XML export since the last update and should (hopefully) not trigger any formatting changes.

Ref: https://youtrack.jetbrains.com/issue/KTIJ-21944

Cc @Doist/android