### PR TITLE
Allow trailing comma, PascalCase const and function in inspections

### DIFF
--- a/configs/codestyles/DoistStyle.xml
+++ b/configs/codestyles/DoistStyle.xml
@@ -32,6 +32,7 @@
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
     <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
+    <option name="ALLOW_TRAILING_COMMA" value="true" />
     <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
   </JetCodeStyleSettings>
   <XML>

--- a/configs/inspection/Doist_Android.xml
+++ b/configs/inspection/Doist_Android.xml
@@ -1,0 +1,16 @@
+<profile version="1.0">
+  <description>Doist style for Android-only projects</description>
+  <option name="myName" value="Doist Android" />
+  <inspection_tool class="ConstPropertyName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <option name="namePattern" value="[A-Z][A-Za-z\d]*" />
+  </inspection_tool>
+  <inspection_tool class="FunctionName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <option name="namePattern" value="[a-zA-Z][A-Za-z\d]*" />
+  </inspection_tool>
+  <inspection_tool class="TestFunctionName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <option name="namePattern" value="[a-zA-Z][A-Za-z_\d]*" />
+  </inspection_tool>
+  <inspection_tool class="TrailingComma" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <option name="addCommaWarning" value="true" />
+  </inspection_tool>
+</profile>

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,30 @@ for i in $HOME/Library/Preferences/IntelliJIdea* \
   fi
 done
 
+echo "Installing Doist inspection configs..."
+
+CONFIGS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/inspection"
+
+for i in $HOME/Library/Preferences/IntelliJIdea* \
+  $HOME/Library/Preferences/IdeaIC* \
+  $HOME/Library/Preferences/AndroidStudio* \
+  $HOME/Library/Application\ Support/JetBrains/IntelliJIdea* \
+  $HOME/Library/Application\ Support/JetBrains/IdeaIC* \
+  $HOME/Library/Application\ Support/Google/AndroidStudio* \
+  $HOME/.IntelliJIdea*/config \
+  $HOME/.IdeaIC*/config \
+  $HOME/.AndroidStudio*/config \
+  $HOME/.config/Google/AndroidStudio* \
+  $HOME/.config/JetBrains/IdeaIC* \
+  $HOME/.config/JetBrains/IntelliJIdea*; do
+  if [[ -d $i ]]; then
+    # Install inspection
+    mkdir -p $i/inspection
+    cp -frv "$CONFIGS/inspection"/* "$i/inspection" 2>/dev/null
+  fi
+done
+
 echo "Done."
 echo ""
-echo "Restart IntelliJ and/or AndroidStudio, go to preferences, and apply 'DoistStyle'."
+echo "Restart IntelliJ and/or Android Studio, go to preferences -> Code Style and apply 'DoistStyle'"
+echo "If in an Android-only project, also go to preferences -> Inspections and apply 'Doist Android'"


### PR DESCRIPTION
Also disallows `_` in Kotlin const to discourage `SCREAMING_SNAKE_CASE`